### PR TITLE
Add geometry msgs

### DIFF
--- a/decode.hpp
+++ b/decode.hpp
@@ -59,3 +59,27 @@ RobotLocation decode(
     dst.frame = src->header()->frame_id()->str();
     return dst;
 }
+
+/*
+ * geometry_msgs
+ */
+
+template <>
+struct flatbuffers_type_for<PoseStamped> {
+    typedef fb::geometry_msgs::PoseStamped type;
+};
+template <>
+PoseStamped decode(
+    const fb::geometry_msgs::PoseStamped* const src) {
+    PoseStamped dst;
+    dst.pose.point.x = src->pose()->position()->x();
+    dst.pose.point.y = src->pose()->position()->y();
+    dst.pose.point.z = src->pose()->position()->z();
+    dst.pose.quaternion.x = src->pose()->orientation()->x();
+    dst.pose.quaternion.y = src->pose()->orientation()->y();
+    dst.pose.quaternion.z = src->pose()->orientation()->z();
+    dst.pose.quaternion.w = src->pose()->orientation()->z();
+    dst.header.frame_id = src->header()->frame_id()->str();
+    return dst;
+}
+

--- a/message_structs.h
+++ b/message_structs.h
@@ -99,6 +99,7 @@ struct Odometry {
 	std::string child_frame_id;
 	PoseWithCovariance pose;
 	TwistWithCovariance twist;
+};
 
 // sensor_msgs
 struct CompressedImage {

--- a/message_structs.h
+++ b/message_structs.h
@@ -11,6 +11,7 @@ struct RobotLocation {
 	std::string frame;
 	float x;
 	float y;
+	float z;
 	float theta;
 };
 
@@ -19,4 +20,77 @@ struct RobotStatus {
 	bool is_ok;
 	float battery_level;
 	std::string location;
+};
+
+
+/*
+ * ROS message clones
+ */
+// std_msgs
+struct Header {
+	std::string frame_id;
+	uint32_t seq;
+};
+
+// geometry_msgs
+struct Point {
+	float x;
+	float y;
+	float z;
+};
+
+struct Quaternion {
+	float x;
+	float y;
+	float z;
+	float w;
+};
+
+struct Vector3 {
+	double x;
+	double y;
+	double z;
+};
+
+struct Pose {
+	Point point;
+	Quaternion quaternion;
+};
+
+struct PoseStamped {
+	Header header;
+	Pose pose;
+};
+
+struct PoseWithCovariance {
+	Pose pose;
+	double covariance[36];
+};
+
+struct PoseWithCovarianceStamped {
+	Header header;
+	PoseWithCovariance pose;
+};
+
+struct Twist {
+	Vector3 linear;
+	Vector3 angular;
+};
+
+struct TwistWithCovariance {
+	Twist twist;
+	double covariance[36];
+};
+
+struct TwistWithCovarianceStamped {
+	Header header;
+	TwistWithCovariance twist;
+};
+
+// nav_msgs
+struct Odometry {
+	Header header;
+	std::string child_frame_id;
+	PoseWithCovariance pose;
+	TwistWithCovariance twist;
 };


### PR DESCRIPTION
This adds common message support for `geometry_msgs` including `PoseStamped`, `Point`, `Quaternion`, `PoseWithCovaraiance`, `PoseWithCovarianceStamped`, `Twist`, `TwistWithCovariance`, `TwistWithCovarianceStamped` and `Odometry`